### PR TITLE
Add disconnect method

### DIFF
--- a/lib/google-u2f-api.js
+++ b/lib/google-u2f-api.js
@@ -121,6 +121,15 @@ u2f.RegisterRequest;
  */
 u2f.RegisterResponse;
 
+/**
+ * Call MessagePort disconnect
+ */
+u2f.disconnect = function () {
+  if (u2f.port_ && u2f.port_.port_) {
+    u2f.port_.port_.disconnect();
+    u2f.port_ = null;
+  }
+};
 
 // Low level MessagePort API support
 

--- a/lib/u2f-api.js
+++ b/lib/u2f-api.js
@@ -54,10 +54,18 @@ function defer( Promise, fun )
 			reject( err );
 		}
 	} );
-	ret.promise.cancel = function( msg )
+	/**
+	 * Reject request promise and disconnect port if 'disconnect' flag is true
+	 * @param {string} msg
+	 * @param {boolean} disconnect
+   */
+	ret.promise.cancel = function( msg, disconnect )
 	{
+		if (disconnect) {
+			coreApi.disconnect();
+		}
 		ret.reject( makeError( msg, { errorCode: -1 } ) )
-	}
+	};
 	return ret;
 }
 


### PR DESCRIPTION
Call disconnect method of MessagePort on cancel request. This is necessary for single page applications.
